### PR TITLE
sorakun loading画面表示　新規画面作成ボタン表示

### DIFF
--- a/navihour_front/src/App.css
+++ b/navihour_front/src/App.css
@@ -51,8 +51,16 @@
 
 .button-right {
   padding-top: 10px;
-  padding-right: 75px;
+  padding-bottom: 10px;
+  padding-right: 30px;
   text-align: right;
+}
+
+.button-left {
+  padding-top: 10px;
+  padding-bottom: 10px;
+  padding-left: 30px;
+  text-align: left;
 }
 
 .center-of-center {

--- a/navihour_front/src/App.css
+++ b/navihour_front/src/App.css
@@ -43,3 +43,32 @@
   flex-direction: row;
   justify-content: space-evenly;
 }
+
+.address-table {
+  padding-left: 50px;
+  padding-right: 50px;
+}
+
+.button-right {
+  padding-top: 10px;
+  padding-right: 75px;
+  text-align: right;
+}
+
+.center-of-center {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+}
+
+.screen-lock{
+  z-index: 9999; /*表示位置を一番手前*/
+  position: fixed; /*fixedを指定(absoluteではスクロールされた時に追従しない)*/
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #808080; /* 背景色（ここではグレー）*/
+  text-align: center;
+  opacity: 0.7; /* 透過値*/
+}

--- a/navihour_front/src/utils/LoadingPage.js
+++ b/navihour_front/src/utils/LoadingPage.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { Paper } from '@material-ui/core';
+import "../App.css";
+
+const useStyles = makeStyles((theme) => ({
+    root: {
+        display: 'flex',
+        '& > * + *': {
+            marginLeft: theme.spacing(2),
+        },
+    },
+}));
+
+export default function LoadingPage() {
+    const classes = useStyles();
+
+    return (
+        <Paper className="screen-lock">
+            <div className={classes.root}>
+                <CircularProgress className="center-of-center"/>
+            </div>
+        </Paper>    
+    );
+}

--- a/navihour_front/src/views/components/Address.js
+++ b/navihour_front/src/views/components/Address.js
@@ -14,8 +14,7 @@ import LockOpenIcon from '@material-ui/icons/LockOpen';
 import LockIcon from '@material-ui/icons/Lock';
 import Button from '@material-ui/core/Button';
 import {getApi } from '../../utils/Api';
-
-// https://material-ui.com/customization/palette/
+import "../../App.css";
 
 class Address extends React.Component {
     constructor(props) {
@@ -85,6 +84,7 @@ class Address extends React.Component {
         // const allAddressList = this.state.allAddressList;
         const allAddressList = this.allAddressList;
         return (
+        <div className="address-table">
             <TableContainer component={Paper}>
                 <Table aria-label="customized table">
                     <TableHead>
@@ -110,6 +110,7 @@ class Address extends React.Component {
                     </TableBody>
                 </Table>
             </TableContainer>
+        </ div>
         );
     }
 }

--- a/navihour_front/src/views/components/Home.js
+++ b/navihour_front/src/views/components/Home.js
@@ -1,9 +1,6 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import Header from '../../utils/Header';
 import Address from './Address'
-import Button from '@material-ui/core/Button';
-import LibraryAddIcon from '@material-ui/icons/LibraryAdd';
 import "../../App.css";
 
 class Home extends React.Component {
@@ -11,13 +8,9 @@ class Home extends React.Component {
             return (
                 <div>
                     <Header />
-                    user_id：{this.props.App_UserId}<br/>
-                    biography：{this.props.App_Biography}<br/>
-                    isLogin：{this.props.App_IsLogin}
-                    <Address />
-                    <div className="button-right">
-                        <Button  component={Link} to="/NewAddress" variant="contained" color="primary"><LibraryAddIcon />New Address</Button>
-                    </div>
+                    <Address 
+                        App_UserId = {localStorage.getItem("user_id")}
+                    />
                 </div>
             );
         }

--- a/navihour_front/src/views/components/Home.js
+++ b/navihour_front/src/views/components/Home.js
@@ -1,6 +1,10 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import Header from '../../utils/Header';
 import Address from './Address'
+import Button from '@material-ui/core/Button';
+import LibraryAddIcon from '@material-ui/icons/LibraryAdd';
+import "../../App.css";
 
 class Home extends React.Component {
     render() {
@@ -11,6 +15,9 @@ class Home extends React.Component {
                     biography：{this.props.App_Biography}<br/>
                     isLogin：{this.props.App_IsLogin}
                     <Address />
+                    <div className="button-right">
+                        <Button  component={Link} to="/NewAddress" variant="contained" color="primary"><LibraryAddIcon />New Address</Button>
+                    </div>
                 </div>
             );
         }

--- a/navihour_front/src/views/components/NewAddress.js
+++ b/navihour_front/src/views/components/NewAddress.js
@@ -5,6 +5,7 @@ import TextField from '@material-ui/core/TextField';
 import Typography from '@material-ui/core/Typography';
 import Container from '@material-ui/core/Container';
 import { UseStyles } from '../../utils/utils';
+import LoadingPage from '../../utils/LoadingPage';
 import HomeSharpIcon from '@material-ui/icons/HomeSharp';
 import StarRateIcon from '@material-ui/icons/StarRate';
 import LockIcon from '@material-ui/icons/Lock';
@@ -13,9 +14,10 @@ import { postApi } from '../../utils/Api';
 import "../../App.css";
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router'
+import ArrowBackIcon from '@material-ui/icons/ArrowBack';
+import { Link } from 'react-router-dom';
 
 class NewAddress extends React.Component {
-    //ToDo user_id は 親コンポーネントから受け取った値を入れる。
     constructor(props) {
         super(props)
         this.state = {
@@ -24,7 +26,8 @@ class NewAddress extends React.Component {
             address_name: PropTypes.string,
             is_favorite: false,
             is_private: true,
-            message: PropTypes.string
+            message: PropTypes.string,
+            is_loding: false,
         }
     }
 
@@ -48,7 +51,12 @@ class NewAddress extends React.Component {
         this.setState({ is_private: !this.state.is_private });
     };
 
+    changeIsLoading = () => {
+        this.setState({ is_loding: !this.state.is_loding });
+    };
+
     registerNewAddress = () => {
+        this.changeIsLoading();
         const json = {
             user_id: this.props.App_UserId,
             address: this.state.address,
@@ -60,11 +68,13 @@ class NewAddress extends React.Component {
         postApi("post_address", json)
             .then((return_json) => {
                 if (return_json["result"] === "OK") {
-                    this.props.history.push('/Home')
+                    this.props.history.push('/Home');
+                    this.changeIsLoading();
                 }
                 else {
                     console.log(return_json["message"]);
                     this.setMessage("※" + return_json["message"]);
+                    this.changeIsLoading();
                 }
             });
     }
@@ -72,6 +82,7 @@ class NewAddress extends React.Component {
     render() {
         return (
             <Container component="main" maxWidth="xs">
+                {this.state.is_loding ? <LoadingPage /> : ""}
                 <CssBaseline />
                 <div className={UseStyles.paper}>
                     <Typography component="h1" variant="h5">
@@ -122,6 +133,16 @@ class NewAddress extends React.Component {
                                 onClick={this.registerNewAddress}
                             >
                                 <HomeSharpIcon />Register
+                            </Button>
+                            <Button
+                                color="default"
+                                component={Link}
+                                fullWidth
+                                to="/Home"
+                                className={UseStyles.submit}
+                                variant="contained"
+                            >
+                                Back <ArrowBackIcon />
                             </Button>
                         </div>
                         <br/><font color="red">{this.state.message}</font>

--- a/navihour_front/src/views/components/NewAddress.js
+++ b/navihour_front/src/views/components/NewAddress.js
@@ -69,13 +69,12 @@ class NewAddress extends React.Component {
             .then((return_json) => {
                 if (return_json["result"] === "OK") {
                     this.props.history.push('/Home');
-                    this.changeIsLoading();
                 }
                 else {
                     console.log(return_json["message"]);
                     this.setMessage("※" + return_json["message"]);
-                    this.changeIsLoading();
                 }
+                this.changeIsLoading();
             });
     }
 


### PR DESCRIPTION
**修正点**
・API通信中のローディング画面を以下のように作成しました。画面上下左右のちょうど中心に表示させます。
(現在は新規アドレス追加のみで使用。実装がOKならほかでも実装予定)
![image](https://user-images.githubusercontent.com/70833575/112756873-f85b8500-9021-11eb-9e7e-eb922728a446.png)

・新規画面ボタンを表示＆テーブルの両サイドに余白を持たせました。
![image](https://user-images.githubusercontent.com/70833575/112756829-d82bc600-9021-11eb-9445-808072261f60.png)


